### PR TITLE
implement a Java version of enry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+target
+.idea
+.jnaerator
+shared
+*.jar
+.enry

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+JNAERATOR_VERSION=ac73c9e
+RESOURCES_DIR=./shared
+LINUX_DIR=$(RESOURCES_DIR)/linux-x86-64
+LINUX_SHARED_LIB=$(LINUX_DIR)/libenry.so
+DARWIN_DIR=$(RESOURCES_DIR)/darwin
+DARWIN_SHARED_LIB=$(DARWIN_DIR)/libenry.dylib
+HEADER_FILE=libenry.h
+NATIVE_LIB_DIR=./.enry
+NATIVE_LIB=$(NATIVE_LIB_DIR)/shared/enry.go
+JARS_DIR=./lib
+JAR=$(JARS_DIR)/enry.jar
+JNAERATOR_DIR=./.jnaerator
+JNAERATOR_JAR=$(JNAERATOR_DIR)/jnaerator.jar
+
+all: $(JAR)
+
+$(JAR): $(NATIVE_LIB) $(JNAERATOR_JAR)
+	mkdir -p lib && \
+	java -jar $(JNAERATOR_JAR) \
+		-package tech.sourced.enry.nativelib \
+		-library enry \
+		$(RESOURCES_DIR)/$(HEADER_FILE) \
+		-o $(JARS_DIR) \
+		-mode StandaloneJar \
+		-runtime JNA;
+
+$(NATIVE_LIB):
+	git clone --depth 1 https://gopkg.in/src-d/enry.v1 $(NATIVE_LIB_DIR)
+
+$(JNAERATOR_JAR):
+	git clone --depth 1 https://github.com/nativelibs4java/jnaerator.git $(JNAERATOR_DIR) && \
+	cd $(JNAERATOR_DIR) && \
+	git checkout $(JNAERATOR_VERSION) && \
+	mvn clean install && \
+	mv jnaerator/target/jnaerator-*-shaded.jar ./jnaerator.jar && \
+	cd ..;
+
+linux-shared: $(LINUX_SHARED_LIB)
+
+darwin-shared: $(DARWIN_SHARED_LIB)
+
+$(DARWIN_SHARED_LIB): $(NATIVE_LIB)
+	mkdir -p $(DARWIN_DIR) && \
+	GOOS=darwin GOARCH=amd64 go build -buildmode=c-shared -o $(DARWIN_SHARED_LIB) $(NATIVE_LIB) && \
+	mv $(DARWIN_DIR)/$(HEADER_FILE) $(RESOURCES_DIR)/$(HEADER_FILE)
+
+$(LINUX_SHARED_LIB): $(NATIVE_LIB)
+	mkdir -p $(LINUX_DIR) && \
+	GOOS=linux GOARCH=amd64 go build -buildmode=c-shared -o $(LINUX_SHARED_LIB) $(NATIVE_LIB) && \
+	mv $(LINUX_DIR)/$(HEADER_FILE) $(RESOURCES_DIR)/$(HEADER_FILE)
+
+test:
+	sbt clean test
+
+package:
+	sbt clean assembly
+
+clean:
+	rm -rf $(JAR)
+	rm -rf $(RESOURCES_DIR)/libenry.h
+	rm -rf $(LINUX_DIR)
+	rm -rf $(DARWIN_DIR)
+	rm -rf $(WINDOWS_DIR)
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# enry-java
+
+### Requirements
+
+* `sbt`
+* `Java` (tested with Java 1.8)
+* `maven` install and on the PATH (only for local usage)
+* `Go` (only for local usage)
+
+### Run tests
+
+```
+make test
+```
+
+### Export jar
+
+```
+make package
+```
+
+Jar will be located in `./target/enry-java-assembly-X.X.X.jar`.

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,51 @@
+name := "enry-java"
+organization := "tech.sourced"
+version := "1.0"
+
+crossPaths := false
+autoScalaLibrary := false
+publishMavenStyle := true
+exportJars := true
+
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
+
+unmanagedBase := baseDirectory.value / "lib"
+unmanagedClasspath in Test += baseDirectory.value / "shared"
+unmanagedClasspath in Runtime += baseDirectory.value / "shared"
+unmanagedClasspath in Compile += baseDirectory.value / "shared"
+testOptions += Tests.Argument(TestFrameworks.JUnit)
+
+lazy val buildNative = taskKey[Unit]("builds native code")
+
+buildNative := {
+  def execCmd(cmd: String, errMsg: String): Unit = {
+    val res = cmd !;
+    if (res != 0) throw new RuntimeException(errMsg)
+  }
+
+  val os = System.getProperty("os.name").toLowerCase();
+  if (os.contains("linux")) {
+    execCmd("make linux-shared", "unable to build linux shared library")
+  } else if (os.contains("mac os")) {
+    execCmd("make darwin-shared", "unable to build darwin dynamic library")
+  } else {
+    throw new RuntimeException("can't build a shared library for " + os)
+  }
+
+  execCmd("make", "unable to generate jar from shared library")
+}
+
+test := {
+  buildNative.value
+  (test in Test).value
+}
+
+compile := {
+  buildNative.value
+  (compile in Compile).value
+}
+
+assembly := {
+  buildNative.value
+  assembly.value
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")

--- a/src/main/java/tech/sourced/enry/Enry.java
+++ b/src/main/java/tech/sourced/enry/Enry.java
@@ -1,0 +1,224 @@
+package tech.sourced.enry;
+
+import tech.sourced.enry.nativelib.*;
+
+import static tech.sourced.enry.GoUtils.*;
+
+public class Enry {
+    private static final EnryLibrary nativeLib = EnryLibrary.INSTANCE;
+
+    /**
+     * Returns whether the given language is auxiliary or not.
+     *
+     * @param language name of the language, e.g. PHP, HTML, ...
+     * @return if it's an auxiliary language
+     */
+    public static boolean isAuxiliaryLanguage(String language) {
+        return toJavaBool(nativeLib.IsAuxiliaryLanguage(toGoString(language)));
+    }
+
+    /**
+     * Returns the language of the given file based on the filename and its
+     * contents.
+     *
+     * @param filename name of the file with the extension
+     * @param content  array of bytes with the contents of the file (the code)
+     * @return the guessed language
+     */
+    public static String getLanguage(String filename, byte[] content) {
+        return toJavaString(nativeLib.GetLanguage(
+                toGoString(filename),
+                toGoByteSlice(content)
+        ));
+    }
+
+    /**
+     * Returns detected language by its content.
+     * If there are more than one possible language, it returns the first
+     * language in alphabetical order and safe to false.
+     *
+     * @param content of the file
+     * @return guessed result
+     */
+    public static Guess getLanguageByContent(byte[] content) {
+        GetLanguageByContent_return.ByValue res = nativeLib.GetLanguageByContent(toGoByteSlice(content));
+        return new Guess(toJavaString(res.r0), toJavaBool(res.r1));
+    }
+
+    /**
+     * Returns detected language by its emacs modeline.
+     * If there are more than one possible language, it returns the first
+     * language in alphabetical order and safe to false.
+     *
+     * @param content of the file
+     * @return guessed result
+     */
+    public static Guess getLanguageByEmacsModeline(byte[] content) {
+        GetLanguageByEmacsModeline_return.ByValue res = nativeLib.GetLanguageByEmacsModeline(toGoByteSlice(content));
+        return new Guess(toJavaString(res.r0), toJavaBool(res.r1));
+    }
+
+    /**
+     * Returns detected language by the extension of the filename.
+     * If there are more than one possible languages, it returns
+     * the first language in alphabetical order and safe to false.
+     *
+     * @param filename of the file
+     * @return guessed result
+     */
+    public static Guess getLanguageByExtension(String filename) {
+        GetLanguageByExtension_return.ByValue res = nativeLib.GetLanguageByExtension(toGoString(filename));
+        return new Guess(toJavaString(res.r0), toJavaBool(res.r1));
+    }
+
+    /**
+     * Returns detected language by its shebang.
+     * If there are more than one possible language, it returns the first
+     * language in alphabetical order and safe to false.
+     *
+     * @param content of the file
+     * @return guessed result
+     */
+    public static Guess getLanguageByShebang(byte[] content) {
+        GetLanguageByShebang_return.ByValue res = nativeLib.GetLanguageByShebang(toGoByteSlice(content));
+        return new Guess(toJavaString(res.r0), toJavaBool(res.r1));
+    }
+
+    /**
+     * Returns detected language by its filename.
+     * If there are more than one possible language, it returns the first
+     * language in alphabetical order and safe to false.
+     *
+     * @param filename of the file
+     * @return guessed result
+     */
+    public static Guess getLanguageByFilename(String filename) {
+        GetLanguageByFilename_return.ByValue res = nativeLib.GetLanguageByFilename(toGoString(filename));
+        return new Guess(toJavaString(res.r0), toJavaBool(res.r1));
+    }
+
+    /**
+     * Returns detected language by its modeline.
+     * If there are more than one possible language, it returns the first
+     * language in alphabetical order and safe to false.
+     *
+     * @param content of the file
+     * @return guessed result
+     */
+    public static Guess getLanguageByModeline(byte[] content) {
+        GetLanguageByModeline_return.ByValue res = nativeLib.GetLanguageByModeline(toGoByteSlice(content));
+        return new Guess(toJavaString(res.r0), toJavaBool(res.r1));
+    }
+
+    /**
+     * Returns detected language by its vim modeline.
+     * If there are more than one possible language, it returns the first
+     * language in alphabetical order and safe to false.
+     *
+     * @param content of the file
+     * @return guessed result
+     */
+    public static Guess getLanguageByVimModeline(byte[] content) {
+        GetLanguageByVimModeline_return.ByValue res = nativeLib.GetLanguageByVimModeline(toGoByteSlice(content));
+        return new Guess(toJavaString(res.r0), toJavaBool(res.r1));
+    }
+
+    /**
+     * Returns all the possible extensions for a file in the given language.
+     *
+     * @param language to get extensions from
+     * @return extensions
+     */
+    public static String[] getLanguageExtensions(String language) {
+        GoSlice result = new GoSlice();
+        nativeLib.GetLanguageExtensions(toGoString(language), result);
+        return toJavaStringArray(result);
+    }
+
+    /**
+     * Returns all possible languages for the given file.
+     *
+     * @param filename of the file
+     * @param content  of the file
+     * @return all possible languages
+     */
+    public static String[] getLanguages(String filename, byte[] content) {
+        GoSlice result = new GoSlice();
+        nativeLib.GetLanguages(toGoString(filename), toGoByteSlice(content), result);
+        return toJavaStringArray(result);
+    }
+
+    /**
+     * Returns the mime type of the file.
+     *
+     * @param path     of the file
+     * @param language of the file
+     * @return mime type
+     */
+    public static String getMimeType(String path, String language) {
+        return toJavaString(nativeLib.GetMimeType(toGoString(path), toGoString(language)));
+    }
+
+    /**
+     * Reports whether the given file content is binary or not.
+     *
+     * @param content of the file
+     * @return whether it's binary or not
+     */
+    public static boolean isBinary(byte[] content) {
+        return toJavaBool(nativeLib.IsBinary(toGoByteSlice(content)));
+    }
+
+    /**
+     * Reports whether the given file or directory is a config file or directory.
+     *
+     * @param path of the file or directory
+     * @return whether it's config or not
+     */
+    public static boolean isConfiguration(String path) {
+        return toJavaBool(nativeLib.IsConfiguration(toGoString(path)));
+    }
+
+    /**
+     * Reports whether the given file or directory it's documentation.
+     *
+     * @param path of the file or directory. It must not contain its parents and
+     *             if it's a directory it must end in a slash e.g. "docs/" or
+     *             "foo.json".
+     * @return whether it's docs or not
+     */
+    public static boolean isDocumentation(String path) {
+        return toJavaBool(nativeLib.IsDocumentation(toGoString(path)));
+    }
+
+    /**
+     * Reports whether the given file is a dotfile.
+     *
+     * @param path of the file
+     * @return whether it's a dotfile or not
+     */
+    public static boolean isDotFile(String path) {
+        return toJavaBool(nativeLib.IsDotFile(toGoString(path)));
+    }
+
+    /**
+     * Reports whether the given path is an image or not.
+     *
+     * @param path of the file
+     * @return whether it's an image or not
+     */
+    public static boolean isImage(String path) {
+        return toJavaBool(nativeLib.IsImage(toGoString(path)));
+    }
+
+    /**
+     * Reports whether the given path is a vendor path or not.
+     *
+     * @param path of the file or directory
+     * @return whether it's vendor or not
+     */
+    public static boolean isVendor(String path) {
+        return toJavaBool(nativeLib.IsVendor(toGoString(path)));
+    }
+
+}

--- a/src/main/java/tech/sourced/enry/GoUtils.java
+++ b/src/main/java/tech/sourced/enry/GoUtils.java
@@ -1,0 +1,73 @@
+package tech.sourced.enry;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
+import tech.sourced.enry.nativelib.GoSlice;
+import tech.sourced.enry.nativelib.GoString;
+
+import java.io.UnsupportedEncodingException;
+
+class GoUtils {
+
+    static GoString.ByValue toGoString(String str) {
+        byte[] bytes;
+        try {
+            bytes = str.getBytes("utf-8");
+        } catch (UnsupportedEncodingException e) {
+            bytes = str.getBytes();
+        }
+
+        GoString.ByValue val = new GoString.ByValue();
+        val.n = bytes.length;
+        Pointer ptr = new Memory(bytes.length);
+        ptr.write(0, bytes, 0, bytes.length);
+        val.p = ptr;
+        return val;
+    }
+
+    static String toJavaString(GoString str) {
+        if (str.n == 0) {
+            return "";
+        }
+
+        byte[] bytes = new byte[(int) str.n];
+        str.p.read(0, bytes, 0, (int) str.n);
+        try {
+            return new String(bytes, "utf-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("utf-8 encoding is not supported");
+        }
+    }
+
+    static String[] toJavaStringArray(GoSlice slice) {
+        String[] result = new String[(int) slice.len];
+        Pointer[] ptrArr = slice.data.getPointerArray(0, (int) slice.len);
+        for (int i = 0; i < (int) slice.len; i++) {
+            result[i] = ptrArr[i].getString(0);
+        }
+        return result;
+    }
+
+    static GoSlice.ByValue toGoByteSlice(byte[] bytes) {
+        return sliceFromPtr(bytes.length, ptrFromBytes(bytes));
+    }
+
+    static GoSlice.ByValue sliceFromPtr(int len, Pointer ptr) {
+        GoSlice.ByValue val = new GoSlice.ByValue();
+        val.cap = len;
+        val.len = len;
+        val.data = ptr;
+        return val;
+    }
+
+    static Pointer ptrFromBytes(byte[] bytes) {
+        Pointer ptr = new Memory(bytes.length);
+        ptr.write(0, bytes, 0, bytes.length);
+        return ptr;
+    }
+
+    static boolean toJavaBool(byte goBool) {
+        return goBool == 1;
+    }
+
+}

--- a/src/main/java/tech/sourced/enry/Guess.java
+++ b/src/main/java/tech/sourced/enry/Guess.java
@@ -1,0 +1,23 @@
+package tech.sourced.enry;
+
+/**
+ * Guess denotes a language detection result of which enry can be
+ * completely sure or not.
+ */
+public class Guess {
+    /**
+     * Result is the resultant language of the detection.
+     */
+    public String result;
+
+    /**
+     * Sure indicates whether the enry was completely sure the language is
+     * the correct one or it might not be.
+     */
+    public boolean sure;
+
+    public Guess(String result, boolean sure) {
+        this.result = result;
+        this.sure = sure;
+    }
+}

--- a/src/test/java/tech/sourced/enry/EnryTest.java
+++ b/src/test/java/tech/sourced/enry/EnryTest.java
@@ -1,0 +1,150 @@
+package tech.sourced.enry;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EnryTest {
+
+    @Test
+    public void isAuxiliaryLanguage() {
+        assertTrue(Enry.isAuxiliaryLanguage("HTML"));
+        assertFalse(Enry.isAuxiliaryLanguage("Go"));
+    }
+
+    @Test
+    public void getLanguage() {
+        String code = "<?php $foo = bar();";
+        assertEquals("PHP", Enry.getLanguage("foobar.php", code.getBytes()));
+    }
+
+    // TODO: this is a bug in enry, fix when it's fixed there
+    @Test(expected = AssertionError.class)
+    public void getLanguageByContent() {
+        String code = "<?php $foo = bar();";
+        assertGuess(
+                "PHP",
+                true,
+                Enry.getLanguageByContent(code.getBytes())
+        );
+    }
+
+    @Test
+    public void getLanguageByEmacsModeline() {
+        String code = "// -*- font:bar;mode:c++ -*-\n" +
+                "template <typename X> class { X i; };";
+        assertGuess(
+                "C++",
+                true,
+                Enry.getLanguageByEmacsModeline(code.getBytes())
+        );
+    }
+
+    @Test
+    public void getLanguageByExtension() {
+        assertGuess(
+                "Ruby",
+                true,
+                Enry.getLanguageByExtension("foo.rb")
+        );
+    }
+
+    @Test
+    public void getLanguageByShebang() {
+        String code = "#!/usr/bin/env python";
+        assertGuess(
+                "Python",
+                true,
+                Enry.getLanguageByShebang(code.getBytes())
+        );
+    }
+
+    @Test
+    public void getLanguageByModeline() {
+        String code = "// -*- font:bar;mode:c++ -*-\n" +
+                "template <typename X> class { X i; };";
+        assertGuess(
+                "C++",
+                true,
+                Enry.getLanguageByModeline(code.getBytes())
+        );
+
+        code = "# vim: noexpandtab: ft=javascript";
+        assertGuess(
+                "JavaScript",
+                true,
+                Enry.getLanguageByModeline(code.getBytes())
+        );
+    }
+
+    @Test
+    public void getLanguageByVimModeline() {
+        String code = "# vim: noexpandtab: ft=javascript";
+        assertGuess(
+                "JavaScript",
+                true,
+                Enry.getLanguageByVimModeline(code.getBytes())
+        );
+    }
+
+    @Test
+    public void getLanguageExtensions() {
+        String[] exts = Enry.getLanguageExtensions("Go");
+        String[] expected = {".go"};
+        assertArrayEquals(expected, exts);
+    }
+
+    @Test
+    public void getLanguages() {
+        String code = "#include <stdio.h>" +
+                "" +
+                "extern int foo(void *bar);";
+
+        String[] result = Enry.getLanguages("foo.h", code.getBytes());
+        String[] expected = {"C", "C++", "Objective-C"};
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    public void getMimeType() {
+        assertEquals(
+                "text/x-ruby",
+                Enry.getMimeType("foo.rb", "Ruby")
+        );
+    }
+
+    @Test
+    public void isBinary() {
+        assertFalse(Enry.isBinary("hello = 'world'".getBytes()));
+    }
+
+    @Test
+    public void isConfiguration() {
+        assertTrue(Enry.isConfiguration("config.yml"));
+        assertFalse(Enry.isConfiguration("FooServiceProviderImplementorFactory.java"));
+    }
+
+    @Test
+    public void isDocumentation() {
+        assertTrue(Enry.isDocumentation("docs/"));
+        assertFalse(Enry.isDocumentation("src/"));
+    }
+
+    @Test
+    public void isDotFile() {
+        assertTrue(Enry.isDotFile(".env"));
+        assertFalse(Enry.isDotFile("config.json"));
+    }
+
+    @Test
+    public void isImage() {
+        assertTrue(Enry.isImage("yup.jpg"));
+        assertFalse(Enry.isImage("nope.go"));
+    }
+
+    void assertGuess(String language, boolean sure, Guess result) {
+        assertEquals(language, result.result);
+        assertEquals(sure, result.sure);
+    }
+
+}


### PR DESCRIPTION
Closes #1 

Implement a Java version of Enry by generating native bindings to the enry Go library.

This works in the following way:
- There's a Go file that contains all exports for C.
- That file is used to generate the libenry.h header file and the libenry.so, libenry.dll and libenry.dylib, depending on the operating system being used.
  Note that for generating these shared libraries one must be in the specific operating system required to build them. That is, you cannot build a macOS .dylib from Windows and so on.
- Using the libenry.h header and JNAerator implementation of the exposed structures and functions in the header are generated for Java in a self-contained jar. The reason why this is generated in a jar and not as plain files is because for some reason, the generation does not produce a valid compilable output, whereas the jar works just fine. This part could have been done manually but would require manual change every time the header file changes. This way, it's just "make" and it works. Because this requires the master version of JNAerator (last tag does work), instead of adding it as a dependency and calling the main function directly with the args, build.sbt calls "make" before the compile phase.
- The bindings generated by JNAerator to implement the interface defined in the header file are not very convenient for the client, so there's a layer on top of that that maps Go values to Java values and vice-versa.
- To generate the generated code jar and the shared libraries, a Makefile is used and then it is called from the `build.sbt`.

Caveats:
- Should we pre-generate the shared libraries when we publish this library?
- Proper testing should be done on both Windows and macOS. While linux generation of shared library works well, they othere two remain untested even though they _should_ work.
- Should we support 32 bits architectures, arm and other operating systems?